### PR TITLE
Update config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     docker:
-      - image: circleci/node:10-browsers
+      - image: cimg/node:18.12.1-browsers
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /home/circleci/project
-      - run: npx angular-cli-ghpages --repo "$GITHUB_ORG/$NAME.git" --name "$GITHUB_NAME" --email "$GITHUB_EMAIL" --branch master
+      - run: npx angular-cli-ghpages --repo "$GITHUB_ORG/$NAME.git" --name "$GITHUB_NAME" --email "$GITHUB_EMAIL" --branch master --message "Auto-generated commit"
 
 
 workflows:


### PR DESCRIPTION
Render supports skipping of builds via "ci skip" message

see https://community.render.com/t/skip-deploy-based-on-commit-message/1699

---

Circle config is outdated (uses Legacy Convenience Docker Image)

see https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034
see https://circleci.com/developer/images/image/cimg/node
see https://hub.docker.com/r/cimg/node/tags